### PR TITLE
Mame4All exit app fix - J_START is code 4, not 7

### DIFF
--- a/examples/mame4all/mame.cfg.template
+++ b/examples/mame4all/mame.cfg.template
@@ -60,7 +60,7 @@ K_A=224
 K_QUIT=41
 #Joystick controls for frontend only
 #Defaults to XBOX360 controller
-J_START=7
+J_START=4
 J_SELECT=6
 J_A=0
 AXIS_LR=0


### PR DESCRIPTION
To exit the mame4all app it looks like the SELECT and START buttons need to be held, but the SDL code for start is incorrect I think. The current 7 value is Left Stick Click.
